### PR TITLE
Support PVC storage for nginx, pipelines and scheduler (+upgrade ingresses)

### DIFF
--- a/apps/nginx/templates/deployment.yaml
+++ b/apps/nginx/templates/deployment.yaml
@@ -31,12 +31,17 @@ spec:
           mountPath: /etc/nginx/htpasswd
           readOnly: true
         {{ end }}
-        {{ if .Values.pipelinesDataNfsServer }}
+        {{- if .Values.pipelinesDataNfsServer }}
         - name: pipelines-data
           mountPath: /pipelines/data
           subPath: data
           readOnly: true
-        {{ end }}
+        {{- else if .Values.pipelinesDataPvcName }}
+        - name: pipelines-data
+          mountPath: /pipelines/data
+          subPath: data
+          readOnly: true
+        {{- end }}
       volumes:
       - name: nginx-conf
         configMap:
@@ -46,10 +51,14 @@ spec:
         secret:
           secretName: {{ .Values.htpasswdSecretName }}
       {{ end }}
-      {{ if .Values.pipelinesDataNfsServer }}
-      - name: pipelines-data
-        nfs:
-          server: {{ .Values.pipelinesDataNfsServer }}
-          path: {{ .Values.pipelinesDataNfsServerPath | default "/" | quote }}
-      {{ end }}
+        {{- if .Values.pipelinesDataNfsServer }}
+        - name: pipelines-data
+          nfs:
+            server: {{ .Values.pipelinesDataNfsServer }}
+            path: {{ .Values.pipelinesDataNfsServerPath | default "/" | quote }}
+        {{- else if .Values.pipelinesDataPvcName }}
+        - name: pipelines-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.pipelinesDataPvcName }}
+        {{- end }}
 {{ end }}

--- a/apps/nginx/values-hasadna.yaml
+++ b/apps/nginx/values-hasadna.yaml
@@ -4,8 +4,10 @@ enableMetrics: false
 enablePipelines: true
 enableAdminer: true
 enableDist: true
-pipelinesDataNfsServer: "172.16.0.9"
-pipelinesDataNfsServerPath: "/mnt/sdb3/srv/default/oknesset/pipelines/data/oknesset-nfs-gcepd"
+# use pipelinesDataPvcName to mount an existing PersistentVolumeClaim instead of NFS
+pipelinesDataPvcName: nginx
+# pipelinesDataNfsServer: "172.16.0.9"
+# pipelinesDataNfsServerPath: "/mnt/sdb3/srv/default/oknesset/pipelines/data/oknesset-nfs-gcepd"
 committeesDomain: oknesset.org
 ingress:
   tls: true

--- a/apps/pipelines/templates/airflow-scheduler-deployment.yaml
+++ b/apps/pipelines/templates/airflow-scheduler-deployment.yaml
@@ -81,14 +81,30 @@ spec:
               subPath: google-service-account-key-json
               mountPath: /var/airflow-google-service-account/key.json
       volumes:
-        - name: airflow-home
-          nfs:
-            server: {{ .Values.nfsServer | quote }}
-            path: {{ .Values.airflow.homeNfsPath | quote }}
-        - name: data
-          nfs:
-            server: {{ .Values.nfsServer | quote }}
-            path: {{ .Values.nfsServerPath }}
+          - name: airflow-home
+            {{- if .Values.enableNfs }}
+            nfs:
+              server: {{ .Values.nfsServer | quote }}
+              path: {{ .Values.airflow.homeNfsPath | quote }}
+            {{- else if .Values.airflowScheduler.pvcName }}
+            persistentVolumeClaim:
+              claimName: {{ .Values.airflowScheduler.pvcName }}
+              # subPath equivalent of airflow home directory
+              # scheduler pvc is expected to contain this directory
+              # this keeps compatibility with previous NFS layout
+              # we rely on existing directory structure
+              # subPath cannot be set here for pvc (k8s limitations),
+              # mount entire pvc and use path inside container
+            {{- end }}
+          - name: data
+            {{- if .Values.enableNfs }}
+            nfs:
+              server: {{ .Values.nfsServer | quote }}
+              path: {{ .Values.nfsServerPath }}
+            {{- else if .Values.airflowScheduler.pvcName }}
+            persistentVolumeClaim:
+              claimName: {{ .Values.airflowScheduler.pvcName }}
+            {{- end }}
         - name: airflow-secret
           secret:
               secretName: airflow

--- a/apps/pipelines/templates/deployment.yaml
+++ b/apps/pipelines/templates/deployment.yaml
@@ -100,13 +100,16 @@ spec:
 #      - name: k8s-ops
 #        secret:
 #          secretName: ops
-      - name: data
-        {{ if .Values.enableNfs }}
-        nfs:
-          server: {{ .Values.nfsServer }}
-          path: {{ .Values.nfsServerPath | default "/" | quote }}
-        {{ else }}
-        gcePersistentDisk:
-          pdName: {{ .Values.persistentDiskName | quote }}
-        {{ end }}
+        - name: data
+          {{- if .Values.enableNfs }}
+          nfs:
+            server: {{ .Values.nfsServer }}
+            path: {{ .Values.nfsServerPath | default "/" | quote }}
+          {{- else if .Values.pvcName }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.pvcName }}
+          {{- else }}
+          gcePersistentDisk:
+            pdName: {{ .Values.persistentDiskName | quote }}
+          {{- end }}
 {{ end }}

--- a/apps/pipelines/values-hasadna.yaml
+++ b/apps/pipelines/values-hasadna.yaml
@@ -4,10 +4,12 @@ DISABLE_MEMBER_PERCENTS: "yes"
 image: orihoch/knesset-data-pipelines
 committeesDomain: oknesset.org
 enableTika: true
-enableNfs: true
+enableNfs: false
+# pvcName defines an existing PersistentVolumeClaim to mount instead of NFS
+pvcName: pipelines
 #  nfsGcePersistentDiskName: oknesset-pipelines-nfs
-nfsServer: "172.16.0.9"
-nfsServerPath: "/mnt/sdb3/srv/default/oknesset/pipelines/data/oknesset-nfs-gcepd"
+# nfsServer: "172.16.0.9"
+# nfsServerPath: "/mnt/sdb3/srv/default/oknesset/pipelines/data/oknesset-nfs-gcepd"
 
 airflowDb:
   image: "postgres:15"
@@ -19,6 +21,7 @@ airflowWebserver:
 
 airflowScheduler:
   resources: '{"requests": {"cpu": "600m", "memory": "8000Mi"}, "limits": {"memory": "12000Mi"}}'
+  pvcName: airflow-scheduler
 
 airflow:
   homeNfsPath: "/oknesset/airflow-home"


### PR DESCRIPTION
## Summary
- add `pipelinesDataPvcName` to nginx values
- support mounting PVC or NFS in nginx deployment
- add `pvcName` and `airflowScheduler.pvcName` to pipelines values
- support mounting PVC in pipelines deployment and airflow-scheduler deployment
- switch default values to use the PVCs

## Testing
- `python -m py_compile update_yaml.py`
- `python update_yaml.py` *(fails: ModuleNotFoundError: No module named 'yaml')*